### PR TITLE
Fix on morton3d encoding

### DIFF
--- a/libmorton/include/morton3D_64.h
+++ b/libmorton/include/morton3D_64.h
@@ -15,7 +15,7 @@ inline uint_fast64_t morton3D_64_Encode_LUT_shifted(const uint_fast32_t x, const
 		Morton3D_64_encode_z_256[(z >> 16) & 0x000000FF] |
 		Morton3D_64_encode_y_256[(y >> 16) & 0x000000FF] |
 		Morton3D_64_encode_x_256[(x >> 16) & 0x000000FF];
-	answer = answer << 48 |
+	answer = answer << 24 |
 		Morton3D_64_encode_z_256[(z >> 8) & 0x000000FF] |
 		Morton3D_64_encode_y_256[(y >> 8) & 0x000000FF] |
 		Morton3D_64_encode_x_256[(x >> 8) & 0x000000FF];
@@ -32,7 +32,7 @@ inline uint_fast64_t morton3D_64_Encode_LUT(const uint_fast32_t x, const uint_fa
 		(Morton3D_64_encode_x_256[(z >> 16) & 0x000000FF] << 2)
 		| (Morton3D_64_encode_x_256[(y >> 16) & 0x000000FF] << 1)
 		| Morton3D_64_encode_x_256[(x >> 16) & 0x000000FF];
-	answer = answer << 48 | 
+	answer = answer << 24 | 
 		(Morton3D_64_encode_x_256[(z >> 8) & 0x000000FF] << 2)
 		| (Morton3D_64_encode_x_256[(y >> 8) & 0x000000FF] << 1)
 		| Morton3D_64_encode_x_256[(x >> 8) & 0x000000FF];
@@ -72,9 +72,10 @@ inline uint_fast64_t morton3D_64_Encode_for(const uint_fast32_t x, const uint_fa
 	checkbits = max(z_max,max(x_max, y_max)) + 1;
 #endif
 	for (uint_fast64_t i = 0; i <= checkbits; ++i) {
-		answer |= ((x & (0x1 << i)) << 2 * i)
-			| ((y & (0x1 << i)) << ((2 * i) + 1))
-			| ((z & (0x1 << i)) << ((2 * i) + 2));
+    //Here we need to cast 0x1 to 64bits, otherwise there is a bug when morton code is larger than 32 bits
+    answer |= ((x & ((uint_fast64_t)0x1 << i)) << 2 * i)
+      | ((y & ((uint_fast64_t)0x1 << i)) << ((2 * i) + 1))
+      | ((z & ((uint_fast64_t)0x1 << i)) << ((2 * i) + 2));
 	}
 	return answer;
 }

--- a/libmorton/include/morton_common.h
+++ b/libmorton/include/morton_common.h
@@ -22,9 +22,9 @@ inline bool findFirstSetBit64(const uint_fast64_t x, unsigned long* firstbit_loc
 	return _BitScanReverse64(firstbit_location, x);
 #elif _MSC_VER && _WIN32
 	firstbit_location = 0;
-	if (_BitScanReverse(&firstbit_location, (x >> 32))){ // check first part
+	if (_BitScanReverse(firstbit_location, (x >> 32))){ // check first part
 		firstbit_location += 32;
-	} else if ( ! _BitScanReverse(&firstbit_location, (x & 0xFFFFFFFF))){ // also test last part
+	} else if ( ! _BitScanReverse(firstbit_location, (x & 0xFFFFFFFF))){ // also test last part
 		return 0;
 	}
 	return true;

--- a/test/libmorton_test.cpp
+++ b/test/libmorton_test.cpp
@@ -72,6 +72,12 @@ static void check3D_EncodeCorrectness(){
 			}
 		}
 	}
+  //test specific values for morton code greater than 32 bits
+  if (morton3D_64_Encode_LUT_shifted(0x1fffff, 0x1fffff, 0x1fffff) != 0x7fffffffffffffff){ printf(" Problem with correctness of LUT based encoding \n");  failures++; }
+  if (morton3D_64_Encode_LUT(0x1fffff, 0x1fffff, 0x1fffff) != 0x7fffffffffffffff){ printf(" Problem with correctness of LUT based encoding \n"); failures++; }
+  if (morton3D_64_Encode_magicbits(0x1fffff, 0x1fffff, 0x1fffff) != 0x7fffffffffffffff){ printf(" Problem with correctness of Magicbits based encoding \n");  failures++; }
+  if (morton3D_64_Encode_for(0x1fffff, 0x1fffff, 0x1fffff) != 0x7fffffffffffffff){ printf(" Problem with correctness of For loop based encoding \n");  failures++; }
+
 	if (failures != 0){printf("Correctness test failed \n");} else {printf("Passed. \n");}
 }
 


### PR DESCRIPTION
Morton3d encoding wasn't working when code was greater than 32 bits.