### PR TITLE
Include <algorithm> to get min and max

### DIFF
--- a/libmorton/include/morton2D.h
+++ b/libmorton/include/morton2D.h
@@ -3,6 +3,7 @@
 // Libmorton - Methods to encode/decode 64-bit morton codes from/to 32-bit (x,y) coordinates
 // Warning: morton.h will always point to the functions that use the fastest available method.
 
+#include <algorithm>
 #include <stdint.h>
 #include <math.h>
 #include "morton2D_LUTs.h"

--- a/libmorton/include/morton3D.h
+++ b/libmorton/include/morton3D.h
@@ -3,6 +3,7 @@
 // Libmorton - Methods to encode/decode 64-bit morton codes from/to 32-bit (x,y,z) coordinates
 // Warning: morton.h will always point to the functions that use the fastest available method.
 
+#include <algorithm>
 #include <stdint.h>
 #include <math.h>
 #include "morton3D_LUTs.h"


### PR DESCRIPTION
I'm having trouble building libmorton with gcc 6.3.0 on Ubuntu 16.04.

`error: there are no arguments to 'max' that depend on a template parameter, so a declaration of 'max' must be available [-fpermissive]
  checkbits = min(static_cast<unsigned long>(checkbits), max(x_max, y_max) + 1ul);`

Including `<alogorithm>` fixes this for me.