### PR TITLE
2D encoding validation and 'For (ET)' fixes

### DIFF
--- a/libmorton/include/morton2D.h
+++ b/libmorton/include/morton2D.h
@@ -121,9 +121,9 @@ namespace libmorton {
 	inline morton m2D_e_for(const coord x, const coord y) {
 		morton answer = 0;
 		unsigned int checkbits = (unsigned int)floor(sizeof(morton) * 4.0f);
-		for (unsigned int i = 0; i <= checkbits; ++i) {
+		for (unsigned int i = 0; i < checkbits; ++i) {
 			morton mshifted = static_cast<morton>(0x1) << i; // Here we need to cast 0x1 to 64bits, otherwise there is a bug when morton code is larger than 32 bits
-			unsigned int shift = 2 * i;
+			unsigned int shift = i;
 			answer |=
 				((x & mshifted) << shift)
 				| ((y & mshifted) << (shift + 1));
@@ -140,9 +140,9 @@ namespace libmorton {
 		findFirstSetBit<morton>(x, &x_max);
 		findFirstSetBit<morton>(y, &y_max);
 		checkbits = min(static_cast<unsigned long>(checkbits), max(x_max, y_max) + 1ul);
-		for (unsigned int i = 0; i <= checkbits; ++i) {
+		for (unsigned int i = 0; i < checkbits; ++i) {
 			morton m_shifted = static_cast<morton>(0x1) << i; // Here we need to cast 0x1 to 64bits, otherwise there is a bug when morton code is larger than 32 bits
-			unsigned int shift = 2 * i;
+			unsigned int shift = i;
 			answer |= ((x & m_shifted) << shift)
 				| ((y & m_shifted) << (shift + 1));
 		}

--- a/libmorton/include/morton2D.h
+++ b/libmorton/include/morton2D.h
@@ -123,7 +123,7 @@ namespace libmorton {
 		unsigned int checkbits = (unsigned int)floor(sizeof(morton) * 4.0f);
 		for (unsigned int i = 0; i < checkbits; ++i) {
 			morton mshifted = static_cast<morton>(0x1) << i; // Here we need to cast 0x1 to 64bits, otherwise there is a bug when morton code is larger than 32 bits
-			unsigned int shift = i;
+			unsigned int shift = i; // because you have to shift back i and forth 2*i
 			answer |=
 				((x & mshifted) << shift)
 				| ((y & mshifted) << (shift + 1));

--- a/libmorton/include/morton_LUT_generators.h
+++ b/libmorton/include/morton_LUT_generators.h
@@ -27,9 +27,9 @@ namespace libmorton {
 
 		if (print_tables) {
 			cout << "X Table " << endl;
-			printTable<uint_fast32_t>(x_table, total, 8);
+			printTable<uint_fast16_t>(x_table, total, 8);
 			cout << "Y Table " << endl;
-			printTable<uint_fast32_t>(y_table, total, 8);
+			printTable<uint_fast16_t>(y_table, total, 8);
 		}
 	}
 

--- a/test/libmorton_test.cpp
+++ b/test/libmorton_test.cpp
@@ -5,6 +5,7 @@
 
 // Utility headers
 #include "libmorton_test.h"
+#include "libmorton_test_2D.h"
 #include "libmorton_test_3D.h"
 
 using namespace std;
@@ -193,7 +194,9 @@ int main(int argc, char *argv[]) {
 	check3D_DecodeCorrectness<uint_fast32_t, uint_fast16_t>(f3D_32_decode);
 
 	cout << "++ Checking 2D methods for correctness" << endl;
-	// TODO
+	check2D_EncodeCorrectness<uint_fast64_t, uint_fast32_t>(f2D_64_encode);
+	check2D_EncodeCorrectness<uint_fast32_t, uint_fast16_t>(f2D_32_encode);
+	// TODO: check 2D decode for correctness
 	
 	cout << "++ Running each performance test " << times << " times and averaging results" << endl;
 	for (int i = 128; i <= 512; i = i * 2){

--- a/test/libmorton_test_2D.h
+++ b/test/libmorton_test_2D.h
@@ -10,6 +10,35 @@ extern size_t MAX;
 extern unsigned int times;
 extern vector<uint_fast64_t> running_sums;
 
+// Check a 2D Encode Function for correctness
+template <typename morton, typename coord>
+static bool check2D_EncodeFunction(const encode_f_2D_wrapper<morton, coord> &function) {
+	bool everything_okay = true;
+	morton computed_code, correct_code = 0;
+	for (coord i = 0; i < 16; i++) {
+		for (coord j = 0; j < 16; j++) {
+			correct_code = control_encode(i, j);
+			computed_code = function.encode(i, j);
+			if (computed_code != correct_code) {
+				everything_okay = false;
+				cout << endl << "    Incorrect encoding of (" << i << ", " << j << ") in method " << function.description.c_str() << ": " << computed_code <<
+					 " != " << correct_code << endl;
+			}
+		}
+	}
+	return everything_okay;
+}
+
+template <typename morton, typename coord>
+inline void check2D_EncodeCorrectness(std::vector<encode_f_2D_wrapper<morton, coord>> encoders) {
+	printf("++ Checking correctness of 2D encoders (%lu bit) methods ... ", sizeof(morton) * 8);
+	bool ok = true;
+	for (auto it = encoders.begin(); it != encoders.end(); it++) {
+		ok &= check2D_EncodeFunction(*it);
+	}
+	ok ? printf(" Passed. \n") : printf("    One or more methods failed. \n");
+}
+
 template <typename morton, typename coord>
 static double testEncode_2D_Linear_Perf(morton(*function)(coord, coord), size_t times) {
 	Timer timer = Timer();

--- a/test/libmorton_test_3D.h
+++ b/test/libmorton_test_3D.h
@@ -18,7 +18,7 @@ static bool check3D_EncodeFunction(const encode_f_3D_wrapper<morton, coord> &fun
 	for (coord i = 0; i < 16; i++) {
 		for (coord j = 0; j < 16; j++) {
 			for (coord k = 0; k < 16; k++) {
-				correct_code = control_3D_Encode[k + (j * 16) + (i * 16 * 16)];
+				correct_code = control_encode(i, j, k);
 				computed_code = function.encode(i, j, k);
 				if (computed_code != correct_code) {
 					everything_okay = false;


### PR DESCRIPTION
While working on [Morton ND](https://github.com/kevinhartman/morton-nd), I wrote an N-dimensional control encode method which I use to test correctness. After integrating it with Libmorton, I came across a bug in the 2D `For` and `For ET` methods (see inline comment adapted from corresponding 3D impls).

This PR includes fixes as well as a port of the validation code. All Libmorton encode methods are now passing, with the exception of `LUT ET` and `LUT ET Shifted`, which (even previously) seem to hang on my system (but very well may be passing on GNU/Linux).

If you'd prefer to use hard-coded LUTs for all validation, we can PR the fixes only up to and including [7c4a8a6](https://github.com/Forceflow/libmorton/commit/7c4a8a655078c97440eb860fd8fd241b74fa286a).

#### Changes
- Integrates validation code for 2D encoding.
- Switches 3D validation code to use same control encoding method used for 2D.
- Fixes a bug in 2D `For` and `For ET` methods found using validation code.
- Fixes a compilation bug (macOS with GCC 8.1) (`printTable`).