### PR TITLE
Prevent accidental introduction of namespace std

### DIFF
--- a/libmorton/include/morton2D.h
+++ b/libmorton/include/morton2D.h
@@ -11,8 +11,6 @@
 
 #define EIGHTBITMASK (morton) 0x000000FF
 
-using namespace std;
-
 namespace libmorton {
 
 	// Encode methods
@@ -139,7 +137,7 @@ namespace libmorton {
 		unsigned int checkbits = sizeof(morton) * 4;
 		findFirstSetBit<morton>(x, &x_max);
 		findFirstSetBit<morton>(y, &y_max);
-		checkbits = min(static_cast<unsigned long>(checkbits), max(x_max, y_max) + 1ul);
+		checkbits = std::min(static_cast<unsigned long>(checkbits), std::max(x_max, y_max) + 1ul);
 		for (unsigned int i = 0; i < checkbits; ++i) {
 			morton m_shifted = static_cast<morton>(0x1) << i; // Here we need to cast 0x1 to 64bits, otherwise there is a bug when morton code is larger than 32 bits
 			unsigned int shift = i;
@@ -249,7 +247,7 @@ namespace libmorton {
 		unsigned long firstbit_location = 0;
 		if (!findFirstSetBit<morton>(m, &firstbit_location)) return;
 		float defaultbits = sizeof(morton) * 4;
-		unsigned int checkbits = static_cast<unsigned int>(min(defaultbits, firstbit_location / 2.0f));
+		unsigned int checkbits = static_cast<unsigned int>(std::min(defaultbits, firstbit_location / 2.0f));
 		for (unsigned int i = 0; i <= checkbits; ++i) {
 			morton selector = 1;
 			unsigned int shift_selector = 2 * i;

--- a/libmorton/include/morton3D.h
+++ b/libmorton/include/morton3D.h
@@ -12,7 +12,6 @@
 #define EIGHTBITMASK (morton) 0x000000FF
 #define NINEBITMASK (morton) 0x000001FF
 
-using namespace std;
 
 namespace libmorton {
 	// AVAILABLE METHODS FOR ENCODING
@@ -148,7 +147,7 @@ namespace libmorton {
 		findFirstSetBit<morton>(x, &x_max);
 		findFirstSetBit<morton>(y, &y_max);
 		findFirstSetBit<morton>(z, &z_max);
-		checkbits = min((unsigned long)checkbits, max(z_max, max(x_max, y_max)) + (unsigned long)1);
+		checkbits = std::min((unsigned long)checkbits, std::max(z_max, std::max(x_max, y_max)) + (unsigned long)1);
 		for (unsigned int i = 0; i < checkbits; ++i) {
 			morton m_shifted = static_cast<morton>(1) << i; // Here we need to cast 0x1 to 64bits, otherwise there is a bug when morton code is larger than 32 bits
 			unsigned int shift = 2 * i;
@@ -273,7 +272,7 @@ namespace libmorton {
 		unsigned long firstbit_location = 0;
 		if (!findFirstSetBit<morton>(m, &firstbit_location)) return;
 		float defaultbits = floor((sizeof(morton) * 8.0f / 3.0f));
-		unsigned int checkbits = static_cast<unsigned int>(min(defaultbits, firstbit_location / 3.0f));
+		unsigned int checkbits = static_cast<unsigned int>(std::min(defaultbits, firstbit_location / 3.0f));
 		for (unsigned int i = 0; i <= checkbits; ++i) {
 			morton selector = 1;
 			unsigned int shift_selector = 3 * i;

--- a/test/libmorton_test.h
+++ b/test/libmorton_test.h
@@ -24,6 +24,8 @@
 #include "../libmorton/include/morton3D.h"
 #include "../libmorton/include/morton.h"
 
+using std::string;
+
 template <typename morton, typename coord>
 struct encode_f_2D_wrapper {
 	string description;
@@ -137,16 +139,16 @@ inline string getSpacedBitString(valtype val, unsigned int frequency, unsigned i
 
 template <typename morton, typename coord>
 void printIncorrectDecoding2D(string method_tested, morton m, coord x, coord y, coord correct_x, coord correct_y) {
-	cout << endl << "    Incorrect decoding of " << getBitString<morton>(m) << " in method " << method_tested.c_str() << ": ("
+	std::cout << "\n    Incorrect decoding of " << getBitString<morton>(m) << " in method " << method_tested.c_str() << ": ("
 		<< getBitString<coord>(x) << ", " << getBitString<coord>(y)
-		<< ") != (" << getBitString<coord>(correct_x) << ", " << getBitString<coord>(correct_y) << ")" << endl;
+		<< ") != (" << getBitString<coord>(correct_x) << ", " << getBitString<coord>(correct_y) << ")\n";
 }
 
 template <typename morton, typename coord>
 void printIncorrectDecoding3D(string method_tested, morton m, coord x, coord y, coord z, coord correct_x, coord correct_y, coord correct_z) {
-	cout << endl << "    Incorrect decoding of " << getBitString<morton>(m) << " in method " << method_tested.c_str() << ": ("
+   std::cout << "\n    Incorrect decoding of " << getBitString<morton>(m) << " in method " << method_tested.c_str() << ": ("
 		<< getBitString<coord>(x) << ", " << getBitString<coord>(y) << ", " << getBitString<coord>(z)
 		<< ") != (" << getBitString<coord>(correct_x) << ", " << getBitString<coord>(correct_y) << ", "
-		<< getBitString<coord>(correct_z) << ")" << endl;
+		<< getBitString<coord>(correct_z) << ")\n";
 }
 

--- a/test/libmorton_test_2D.h
+++ b/test/libmorton_test_2D.h
@@ -1,14 +1,13 @@
 #pragma once
 #include "libmorton_test.h"
 
-using namespace std;
 
 // Config variables (defined elsewhere)
 extern size_t RAND_POOL_SIZE;
 extern size_t total;
 extern size_t MAX;
 extern unsigned int times;
-extern vector<uint_fast64_t> running_sums;
+extern std::vector<uint_fast64_t> running_sums;
 
 // Check a 2D Encode Function for correctness
 template <typename morton, typename coord, size_t bits>
@@ -37,8 +36,8 @@ static bool check2D_EncodeFunction(const encode_f_2D_wrapper<morton, coord> &fun
 				computed_code = function.encode(x, y);
 				if (computed_code != (morton)correct_code) {
 					everything_okay = false;
-					cout << endl << "    Incorrect encoding of (" << x << ", " << y << ") in method " << function.description.c_str() << ": " << computed_code <<
-						" != " << (morton)correct_code << endl;
+					std::cout << "\n    Incorrect encoding of (" << x << ", " << y << ") in method " << function.description.c_str() << ": " << computed_code <<
+						" != " << (morton)correct_code << "\n";
 				}
 			}
 		}
@@ -140,7 +139,7 @@ static double testEncode_2D_Random_Perf(morton(*function)(coord, coord), size_t 
 
 	for (size_t t = 0; t < times; t++) {
 		// Create a pool of random numbers
-		vector<coord> randnumbers;
+		std::vector<coord> randnumbers;
 		for (size_t i = 0; i < RAND_POOL_SIZE; i++) {
 			randnumbers.push_back(rand() % maximum);
 		}

--- a/test/libmorton_test_3D.h
+++ b/test/libmorton_test_3D.h
@@ -1,14 +1,13 @@
 #pragma once
 #include "libmorton_test.h"
 
-using namespace std;
 
 // Config variables (defined elsewhere)
 extern size_t RAND_POOL_SIZE;
 extern size_t total;
 extern size_t MAX;
 extern unsigned int times;
-extern vector<uint_fast64_t> running_sums;
+extern std::vector<uint_fast64_t> running_sums;
 
 // Check a 3D Encode Function for correctness
 template <typename morton, typename coord, size_t bits>
@@ -39,8 +38,8 @@ static bool check3D_EncodeFunction(const encode_f_3D_wrapper<morton, coord> &fun
 					computed_code = function.encode(x, y, z);
 					if (computed_code != (morton)correct_code) {
 						everything_okay = false;
-						cout << endl << "    Incorrect encoding of (" << x << ", " << y << ", " << z << ") in method " << function.description.c_str() << ": " << computed_code <<
-							" != " << (morton)correct_code << endl;
+						std::cout << "\n    Incorrect encoding of (" << x << ", " << y << ", " << z << ") in method " << function.description.c_str() << ": " << computed_code <<
+							" != " << (morton)correct_code << "\n";
 					}
 				}
 			}
@@ -111,15 +110,15 @@ inline bool check3D_Match(const encode_f_3D_wrapper<morton, coord> &encode, deco
 		morton mortonresult = encode.encode(x, y, z);
 		decode.decode(mortonresult, x_result, y_result, z_result);
 		if ((x != x_result) | (y != y_result) | (z != z_result)) {
-			cout << endl << "x: " << getBitString<coord>(x) << " (" << x << ")" << endl;
-			cout << "y: " << getBitString<coord>(y) << " (" << y << ")" << endl;
-			cout << "z: " << getBitString<coord>(z) << " (" << z << ")" << endl;
-			cout << "morton: " << getBitString<morton>(mortonresult) << "(" << mortonresult << ")" << endl;
-			cout << "x_result: " << getBitString<coord>(x_result) << " (" << x_result << ")" << endl;
-			cout << "y_result: " << getBitString<coord>(y_result) << " (" << y_result << ")" << endl;
-			cout << "z_result: " << getBitString<coord>(z_result) << " (" << z_result << ")" << endl;
-			cout << bits << "-bit ";
-			cout << "using methods encode " << encode.description << " and decode " << decode.description << endl;
+			std::cout << "\n" << "x: " << getBitString<coord>(x) << " (" << x << ")\n";
+			std::cout << "y: " << getBitString<coord>(y) << " (" << y << ")\n";
+			std::cout << "z: " << getBitString<coord>(z) << " (" << z << ")\n";
+			std::cout << "morton: " << getBitString<morton>(mortonresult) << "(" << mortonresult << ")\n";
+			std::cout << "x_result: " << getBitString<coord>(x_result) << " (" << x_result << ")\n";
+			std::cout << "y_result: " << getBitString<coord>(y_result) << " (" << y_result << ")\n";
+			std::cout << "z_result: " << getBitString<coord>(z_result) << " (" << z_result << ")\n";
+			std::cout << bits << "-bit ";
+			std::cout << "using methods encode " << encode.description << " and decode " << decode.description << "\n";
 			everythingokay = false;
 		}
 	}
@@ -197,7 +196,7 @@ static double testEncode_3D_Random_Perf(morton(*function)(coord, coord, coord), 
 
 	for (size_t t = 0; t < times; t++) {
 		// Create a pool of random numbers
-		vector<coord> randnumbers;
+      std::vector<coord> randnumbers;
 		for (size_t i = 0; i < RAND_POOL_SIZE; i++) {
 			randnumbers.push_back(rand() % maximum);
 		}
@@ -265,7 +264,7 @@ static double testDecode_3D_Random_Perf(void(*function)(const morton, coord&, co
 	morton m;
 
 	// Create a pool of randum numbers
-	vector<morton> randnumbers;
+   std::vector<morton> randnumbers;
 	for (size_t i = 0; i < RAND_POOL_SIZE; i++) {
 		randnumbers.push_back((rand() + rand()) % maximum);
 	}

--- a/test/morton_LUT_generators.h
+++ b/test/morton_LUT_generators.h
@@ -9,10 +9,10 @@ namespace libmorton {
 	template <typename element>
 	void printTable(const element* table, size_t howmany, unsigned int splitat) {
 		for (size_t i = 0; i < howmany; i++) {
-			if (i % splitat == 0) { cout << endl; }
+			if (i % splitat == 0) { std::cout << "\n"; }
 			printf("%u ,", static_cast<unsigned int>(table[i]));
 		}
-		cout << endl;
+		std::cout << "\n";
 	}
 
 	void generate2D_EncodeLUT(size_t how_many_bits, uint_fast16_t*& x_table, uint_fast16_t*& y_table, bool print_tables) {
@@ -26,9 +26,9 @@ namespace libmorton {
 		}
 
 		if (print_tables) {
-			cout << "X Table " << endl;
+			std::cout << "X Table \n";
 			printTable<uint_fast16_t>(x_table, total, 8);
-			cout << "Y Table " << endl;
+			std::cout << "Y Table \n";
 			printTable<uint_fast16_t>(y_table, total, 8);
 		}
 	}
@@ -44,9 +44,9 @@ namespace libmorton {
 		}
 
 		if (print_tables) {
-			cout << "X Table " << endl;
+			std::cout << "X Table \n";
 			printTable<uint_fast8_t>(x_table, total, 16);
-			cout << "Y Table " << endl;
+			std::cout << "Y Table \n";
 			printTable<uint_fast8_t>(y_table, total, 16);
 		}
 	}
@@ -65,11 +65,11 @@ namespace libmorton {
 		}
 
 		if (print_tables) {
-			cout << "X Table " << endl;
+			std::cout << "X Table \n";
 			printTable<uint_fast32_t>(x_table, total, 8);
-			cout << "Y Table " << endl;
+			std::cout << "Y Table \n";
 			printTable<uint_fast32_t>(y_table, total, 8);
-			cout << "Z Table " << endl;
+			std::cout << "Z Table \n";
 			printTable<uint_fast32_t>(z_table, total, 8);
 		}
 	}
@@ -90,11 +90,11 @@ namespace libmorton {
 		}
 
 		if (print_tables) {
-			cout << "X Table " << endl;
+			std::cout << "X Table \n";
 			printTable<uint_fast8_t>(x_table, total, 16);
-			cout << "Y Table " << endl;
+			std::cout << "Y Table \n";
 			printTable<uint_fast8_t>(y_table, total, 16);
-			cout << "Z Table " << endl;
+			std::cout << "Z Table \n";
 			printTable<uint_fast8_t>(z_table, total, 16);
 		}
 	}

--- a/test/msvc2019/libmorton_test.vcxproj
+++ b/test/msvc2019/libmorton_test.vcxproj
@@ -84,6 +84,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -95,6 +96,7 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -118,6 +120,7 @@
       <FloatingPointModel>Fast</FloatingPointModel>
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
+      <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>
@@ -144,6 +147,7 @@
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <OpenMPSupport>true</OpenMPSupport>
+      <PreprocessorDefinitions>NOMINMAX;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <GenerateDebugInformation>true</GenerateDebugInformation>

--- a/test/timer.h
+++ b/test/timer.h
@@ -10,8 +10,6 @@
 #include "time.h"
 #endif
 
-using namespace std;
-
 #if _MSC_VER
 struct Timer { 
 	double pc_frequency = 0.0;

--- a/test/util.h
+++ b/test/util.h
@@ -4,7 +4,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-using namespace std;
 
 static uint32_t x[4096];
 static uint32_t c = 362;


### PR DESCRIPTION
Headers containing `using namespace`  introduce all the names of the namespace into each file where it is included. This could lead to hard to find problems, as its source is not easily detectable.