### PR TITLE
_mm512_bitshuffle_epi64_mask implementation

### DIFF
--- a/libmorton/include/morton.h
+++ b/libmorton/include/morton.h
@@ -9,13 +9,27 @@
 #include "morton2D.h"
 #include "morton3D.h"
 #include "morton_BMI.h"
+#include "morton_AVX512BITALG.h"
 
 namespace libmorton {
 	// Functions under this are stubs which will always point to fastest implementation at the moment
 	//-----------------------------------------------------------------------------------------------
 
 	// ENCODING
-#if defined(__BMI2__) || __AVX2__
+#if defined(__AVX512BITALG__)
+	inline uint_fast32_t morton2D_32_encode(const uint_fast16_t x, const uint_fast16_t y) {
+		return m2D_e_BITALG<uint_fast32_t, uint_fast16_t>(x, y);
+	}
+	inline uint_fast64_t morton2D_64_encode(const uint_fast32_t x, const uint_fast32_t y) {
+		return m2D_e_BITALG<uint_fast64_t, uint_fast32_t>(x, y);
+	}
+	inline uint_fast32_t morton3D_32_encode(const uint_fast16_t x, const uint_fast16_t y, const uint_fast16_t z) {
+		return m3D_e_BITALG<uint_fast32_t, uint_fast16_t>(x, y, z);
+	}
+	inline uint_fast64_t morton3D_64_encode(const uint_fast32_t x, const uint_fast32_t y, const uint_fast32_t z) {
+		return m3D_e_BITALG<uint_fast64_t, uint_fast32_t>(x, y, z);
+	}
+#elif defined(__BMI2__) || __AVX2__
 	inline uint_fast32_t morton2D_32_encode(const uint_fast16_t x, const uint_fast16_t y) {
 		return m2D_e_BMI<uint_fast32_t, uint_fast16_t>(x, y);
 	}
@@ -44,7 +58,20 @@ namespace libmorton {
 #endif
 
 	// DECODING
-#if defined(__BMI2__) || __AVX2__
+#if defined(__AVX512BITALG__)
+	inline void morton2D_32_decode(const uint_fast32_t morton, uint_fast16_t& x, uint_fast16_t& y) {
+		m2D_d_BITALG<uint_fast32_t, uint_fast16_t>(morton, x, y);
+	}
+	inline void morton2D_64_decode(const uint_fast64_t morton, uint_fast32_t& x, uint_fast32_t& y) {
+		m2D_d_BITALG<uint_fast64_t, uint_fast32_t>(morton, x, y);
+	}
+	inline void morton3D_32_decode(const uint_fast32_t morton, uint_fast16_t& x, uint_fast16_t& y, uint_fast16_t& z) {
+		m3D_d_BITALG<uint_fast32_t, uint_fast16_t>(morton, x, y, z);
+	}
+	inline void morton3D_64_decode(const uint_fast64_t morton, uint_fast32_t& x, uint_fast32_t& y, uint_fast32_t& z) {
+		m3D_d_BITALG<uint_fast64_t, uint_fast32_t>(morton, x, y, z);
+	}
+#elif defined(__BMI2__) || __AVX2__
 	inline void morton2D_32_decode(const uint_fast32_t morton, uint_fast16_t& x, uint_fast16_t& y) {
 		m2D_d_BMI<uint_fast32_t, uint_fast16_t>(morton, x, y);
 	}

--- a/libmorton/include/morton_AVX512BITALG.h
+++ b/libmorton/include/morton_AVX512BITALG.h
@@ -1,5 +1,4 @@
 #pragma once
-#if defined(__AVX512BITALG__)
 #include <immintrin.h>
 #include <stdint.h>
 
@@ -9,31 +8,29 @@ namespace libmorton {
 		// "Zip" and interleave an m-vector of n-bit integers into a
 		// new n*m-bit integer
 		// 2D MORTONS
-		// zip two 16-bit coords into a 32-bit morton
-		inline uint32_t bitzip(uint16_t a, uint16_t b) noexcept {
-			// Put both 16-bit integers into each 32-bit lane
-			const __m256i CoordVec = _mm256_set1_epi32(
-				(static_cast<uint32_t>(b) << 16u) | a
-			);
-			// Interleave bits from 32-bit X and Y coordinate
-			const __mmask32 Interleave = _mm256_bitshuffle_epi64_mask(
-				CoordVec,
-				_mm256_set_epi16(
-					0x1000 + 0x0101 * 15, 0x1000 + 0x0101 * 14,
-					0x1000 + 0x0101 * 13, 0x1000 + 0x0101 * 12,
-					0x1000 + 0x0101 * 11, 0x1000 + 0x0101 * 10,
-					0x1000 + 0x0101 *  9, 0x1000 + 0x0101 *  8,
-					0x1000 + 0x0101 *  7, 0x1000 + 0x0101 *  6,
-					0x1000 + 0x0101 *  5, 0x1000 + 0x0101 *  4,
-					0x1000 + 0x0101 *  3, 0x1000 + 0x0101 *  2,
-					0x1000 + 0x0101 *  1, 0x1000 + 0x0101 *  0
-				)
-			);
-			return _cvtmask32_u32(Interleave);
-		}
-		
-		// zip two 32-bit coords into a 64-bit morton
-		inline uint64_t bitzip(uint32_t a, uint32_t b) noexcept {
+		// inline uint16_t bitzip2D(uint16_t a, uint16_t b) noexcept {
+		// 	// Put both 16-bit integers into each 32-bit lane
+		// 	const __m256i CoordVec = _mm256_set1_epi32(
+		// 		(static_cast<uint32_t>(b) << 16u) | a
+		// 	);
+		// 	// Interleave bits from 32-bit X and Y coordinate
+		// 	const __mmask32 Interleave = _mm256_bitshuffle_epi64_mask(
+		// 		CoordVec,
+		// 		_mm256_set_epi16(
+		// 			0x1000 + 0x0101 * 15, 0x1000 + 0x0101 * 14,
+		// 			0x1000 + 0x0101 * 13, 0x1000 + 0x0101 * 12,
+		// 			0x1000 + 0x0101 * 11, 0x1000 + 0x0101 * 10,
+		// 			0x1000 + 0x0101 *  9, 0x1000 + 0x0101 *  8,
+		// 			0x1000 + 0x0101 *  7, 0x1000 + 0x0101 *  6,
+		// 			0x1000 + 0x0101 *  5, 0x1000 + 0x0101 *  4,
+		// 			0x1000 + 0x0101 *  3, 0x1000 + 0x0101 *  2,
+		// 			0x1000 + 0x0101 *  1, 0x1000 + 0x0101 *  0
+		// 		)
+		// 	);
+		// 	return _cvtmask32_u32(Interleave);
+		// }
+
+		inline uint64_t bitzip2D(uint64_t a, uint64_t b) noexcept {
 			// Put both 32-bit integers into each 64-bit lane
 			const __m512i CoordVec = _mm512_set1_epi64(
 				(static_cast<uint64_t>(b) << 32u) | a
@@ -62,84 +59,108 @@ namespace libmorton {
 			);
 			return _cvtmask64_u64(Interleave);
 		}
-		// 3D MORTONS
-		// zip three 16-bit coords into a 32-bit morton
-		inline uint32_t bitzip(uint16_t a, uint16_t b, uint16_t c) noexcept {
-			// Put both 32-bit integers into each 64-bit lane
-			const __m256i CoordVec = _mm256_set1_epi64x(
-				static_cast<std::uint64_t>(a)
-				| static_cast<std::uint64_t>(b << 16)
-				| static_cast<std::uint64_t>(c << 32)
+		inline uint32_t bitzip2D(uint32_t a, uint32_t b) noexcept {
+			return bitzip2D(
+				static_cast<uint64_t>(a),
+				static_cast<uint64_t>(b)
 			);
-			// Interleave bits from 16-bit X and Y and Z coordinate
-			const __mmask32 Interleave = _mm256_bitshuffle_epi64_mask(
-				CoordVec,
-				_mm256_set_epi64x(
-					0x1A'0A'29'19'09'28'18'08, // Byte 3
-					0x27'17'07'26'16'06'25'15, // Byte 2
-					0x05'24'14'04'23'13'03'22, // Byte 1
-					0x12'02'21'11'01'20'10'00  // Byte 0
-				)
-			);
-			return _cvtmask32_u32(Interleave));
 		}
-		// zip three 32-bit coords into a 64-bit morton
-		inline uint64_t bitzip(uint32_t a, uint32_t b, uint32_t c) noexcept {
+		// 3D MORTONS
+		// inline uint16_t bitzip3D(uint16_t a, uint16_t b, uint16_t c) noexcept {
+		// 	// Put both 32-bit integers into each 64-bit lane
+		// 	const __m256i CoordVec = _mm256_set1_epi64x(
+		// 		static_cast<std::uint64_t>(a)
+		// 		| (static_cast<std::uint64_t>(b) << 16)
+		// 		| (static_cast<std::uint64_t>(c) << 32)
+		// 	);
+		// 	// Interleave bits from 16-bit X and Y and Z coordinate
+		// 	const __mmask32 Interleave = _mm256_bitshuffle_epi64_mask(
+		// 		CoordVec,
+		// 		_mm256_set_epi64x(
+		// 			0x1A0A291909281808, // Byte 3
+		// 			0x2717072616062515, // Byte 2
+		// 			0x0524140423130322, // Byte 1
+		// 			0x1202211101201000  // Byte 0
+		// 		)
+		// 	);
+		// 	return _cvtmask32_u32(Interleave);
+		// }
+		inline uint64_t bitzip3D(uint64_t a, uint64_t b, uint64_t c) noexcept {
 			// Put both 32-bit integers into each 64-bit lane
-			const __m512i CoordVec = _mm512_broadcast_i32x4(
-				_mm_set_epi32(0, c, b, a)
+			// Todo: _mm512_shuffle_epi8 version, 128-bit lane woes
+			const __m512i CoordVec = _mm512_set_epi64(
+				0, 0, 0, 0, 0, c, b, a
 			);
-			const __m512i ShuffleVec = _mm512_shuffle_epi8(
-				CoordVec,
+			const __m512i ShuffleVec = _mm512_permutexvar_epi8(
 				_mm512_set_epi64(
-					0x0A'06'02ul, // Lane 7 | z2 | y2 | x2
-					0x0A'06'02ul, // Lane 6 | z2 | y2 | x2
-					0x09'05'01ul, // Lane 5 | z1 | y1 | x1
-					0x09'05'01ul, // Lane 4 | z1 | y1 | x1
-					0x09'05'01ul, // Lane 3 | z1 | y1 | x1
-					0x08'04'00ul, // Lane 2 | z0 | y0 | x0
-					0x08'04'00ul, // Lane 1 | z0 | y0 | x0
-					0x08'04'00ul  // Lane 0 | z0 | y0 | x0
-				)
+					0xFFFFFFFFFF100800ul + 0x010101 * 2, // Lane 7 | ...000 | z[2] | y[2] | x[2]
+					0xFFFFFFFFFF100800ul + 0x010101 * 2, // Lane 6 | ...000 | z[2] | y[2] | x[2]
+					0xFFFFFFFFFF100800ul + 0x010101 * 1, // Lane 5 | ...000 | z[1] | y[1] | x[1]
+					0xFFFFFFFFFF100800ul + 0x010101 * 1, // Lane 4 | ...000 | z[1] | y[1] | x[1]
+					0xFFFFFFFFFF100800ul + 0x010101 * 1, // Lane 3 | ...000 | z[1] | y[1] | x[1]
+					0xFFFFFFFFFF100800ul + 0x010101 * 0, // Lane 2 | ...000 | z[0] | y[0] | x[0]
+					0xFFFFFFFFFF100800ul + 0x010101 * 0, // Lane 1 | ...000 | z[0] | y[0] | x[0]
+					0xFFFFFFFFFF100800ul + 0x010101 * 0  // Lane 0 | ...000 | z[0] | y[0] | x[0]
+				),
+				CoordVec
+			);
+			const __m512i BitIndex =
+			_mm512_set_epi64(
+				0x0504040403030302 + 0x0002010002010002 * 8,
+				0x0202010101000000 + 0x0100020100020100 * 8,
+				0x0707070606060505 + 0x0201000201000201 * 8,
+				0x0504040403030302 + 0x0002010002010002 * 8,
+				0x0202010101000000 + 0x0100020100020100 * 8,
+				0x0707070606060505 + 0x0201000201000201 * 8,
+				0x0504040403030302 + 0x0002010002010002 * 8,
+				0x0202010101000000 + 0x0100020100020100 * 8 
 			);
 			// Interleave bits from 32-bit X and Y and Z coordinate
 			const __mmask64 Interleave = _mm512_bitshuffle_epi64_mask(
-				ShuffleVec,
-				_mm512_set_epi64(
-					0x15'14'14'14'13'13'13'12, // Byte 7
-					0x12'12'11'11'11'10'10'10, // Byte 6
-					0x0F'0F'0F'0E'0E'0E'0D'0D, // Byte 5
-					0x0D'0C'0C'0C'0B'0B'0B'0A, // Byte 4
-					0x0A'0A'09'09'09'08'08'08, // Byte 3
-					0x07'07'07'06'06'06'05'05, // Byte 2
-					0x05'04'04'04'03'03'03'02, // Byte 1
-					0x02'02'01'01'01'00'00'00  // Byte 0
-				)
+				ShuffleVec, BitIndex
 			);
 			return _cvtmask64_u64(Interleave);
+		}
+		inline uint32_t bitzip3D(uint32_t a, uint32_t b, uint32_t c) noexcept {
+			return bitzip3D(
+				static_cast<uint64_t>(a),
+				static_cast<uint64_t>(b),
+				static_cast<uint64_t>(c)
+			);
 		}
 	}  // namespace bitalg_detail
 
 	template<typename morton, typename coord>
 	inline morton m2D_e_BITALG(const coord x, const coord y) {
-		return bitalg_detail::bitzip(
+		return bitalg_detail::bitzip2D(
 			static_cast<coord>(x), static_cast<coord>(y)
 		);
 	}
 
 	template<typename morton, typename coord>
 	inline void m2D_d_BITALG(const morton m, coord& x, coord& y) {
+		// Placeholder BMI implementation for verification
+		#define BMI_2D_X_MASK 0x5555555555555555
+		#define BMI_2D_Y_MASK 0xAAAAAAAAAAAAAAAA
+		x = static_cast<coord>(bmi2_detail::pext(m, static_cast<morton>(BMI_3D_X_MASK)));
+		y = static_cast<coord>(bmi2_detail::pext(m, static_cast<morton>(BMI_3D_Y_MASK)));
 	}
 
 	template<typename morton, typename coord>
 	inline morton m3D_e_BITALG(const coord x, const coord y, const coord z) {
-		return bitalg_detail::bitzip(
+		return bitalg_detail::bitzip3D(
 			static_cast<coord>(x), static_cast<coord>(y),  static_cast<coord>(z)
 		);
 	}
 
 	template<typename morton, typename coord>
 	inline void m3D_d_BITALG(const morton m, coord& x, coord& y, coord& z) {
+		// Placeholder BMI implementation for verification
+		#define BMI_3D_X_MASK 0x9249249249249249
+		#define BMI_3D_Y_MASK 0x2492492492492492
+		#define BMI_3D_Z_MASK 0x4924924924924924
+		x = static_cast<coord>(bmi2_detail::pext(m, static_cast<morton>(BMI_3D_X_MASK)));
+		y = static_cast<coord>(bmi2_detail::pext(m, static_cast<morton>(BMI_3D_Y_MASK)));
+		z = static_cast<coord>(bmi2_detail::pext(m, static_cast<morton>(BMI_3D_Z_MASK)));
 	}
 }
-#endif

--- a/libmorton/include/morton_AVX512BITALG.h
+++ b/libmorton/include/morton_AVX512BITALG.h
@@ -1,0 +1,29 @@
+#pragma once
+#if defined(__AVX512BITALG__)
+#include <immintrin.h>
+#include <stdint.h>
+
+namespace libmorton {
+
+	namespace bitalg_detail {
+	}  // namespace bitalg_detail
+
+	template<typename morton, typename coord>
+	inline morton m2D_e_BITALG(const coord x, const coord y) {
+		return morton(0);
+	}
+
+	template<typename morton, typename coord>
+	inline void m2D_d_BITALG(const morton m, coord& x, coord& y) {
+	}
+
+	template<typename morton, typename coord>
+	inline morton m3D_e_BITALG(const coord x, const coord y, const coord z) {
+		return morton(0);
+	}
+
+	template<typename morton, typename coord>
+	inline void m3D_d_BITALG(const morton m, coord& x, coord& y, coord& z) {
+	}
+}
+#endif

--- a/libmorton/include/morton_AVX512BITALG.h
+++ b/libmorton/include/morton_AVX512BITALG.h
@@ -6,11 +6,70 @@
 namespace libmorton {
 
 	namespace bitalg_detail {
+		// "Zip" and interleave an m-vector of n-bit integers into a
+		// new n*m-bit integer
+
+		// zip two 16-bit coords into a 32-bit morton
+		inline uint32_t bitzip(uint16_t a, uint16_t b) noexcept {
+			// Put both 16-bit integers into each 32-bit lane
+			const __m256i CoordVec = _mm256_set1_epi32(
+				(static_cast<uint32_t>(b) << 16u) | a
+			);
+			// Interleave bits from 32-bit X and Y coordinate
+			const __mmask32 Interleave = _mm256_bitshuffle_epi64_mask(
+				CoordVec,
+				_mm256_set_epi16(
+					0x1000 + 0x0101 * 15, 0x1000 + 0x0101 * 14,
+					0x1000 + 0x0101 * 13, 0x1000 + 0x0101 * 12,
+					0x1000 + 0x0101 * 11, 0x1000 + 0x0101 * 10,
+					0x1000 + 0x0101 *  9, 0x1000 + 0x0101 *  8,
+					0x1000 + 0x0101 *  7, 0x1000 + 0x0101 *  6,
+					0x1000 + 0x0101 *  5, 0x1000 + 0x0101 *  4,
+					0x1000 + 0x0101 *  3, 0x1000 + 0x0101 *  2,
+					0x1000 + 0x0101 *  1, 0x1000 + 0x0101 *  0
+				)
+			);
+			return _cvtmask32_u32(Interleave);
+		}
+		
+		// zip two 32-bit coords into a 64-bit morton
+		inline uint64_t bitzip(uint32_t a, uint32_t b) noexcept {
+			// Put both 32-bit integers into each 64-bit lane
+			const __m512i CoordVec = _mm512_set1_epi64(
+				(static_cast<uint64_t>(b) << 32u) | a
+			);
+			// Interleave bits from 32-bit X and Y coordinate
+			const __mmask64 Interleave = _mm512_bitshuffle_epi64_mask(
+				CoordVec,
+				_mm512_set_epi16(
+					0x2000 + 0x0101 * 31, 0x2000 + 0x0101 * 30,
+					0x2000 + 0x0101 * 29, 0x2000 + 0x0101 * 28,
+					0x2000 + 0x0101 * 27, 0x2000 + 0x0101 * 26,
+					0x2000 + 0x0101 * 25, 0x2000 + 0x0101 * 24,
+					0x2000 + 0x0101 * 23, 0x2000 + 0x0101 * 22,
+					0x2000 + 0x0101 * 21, 0x2000 + 0x0101 * 20,
+					0x2000 + 0x0101 * 19, 0x2000 + 0x0101 * 18,
+					0x2000 + 0x0101 * 17, 0x2000 + 0x0101 * 16,
+					0x2000 + 0x0101 * 15, 0x2000 + 0x0101 * 14,
+					0x2000 + 0x0101 * 13, 0x2000 + 0x0101 * 12,
+					0x2000 + 0x0101 * 11, 0x2000 + 0x0101 * 10,
+					0x2000 + 0x0101 *  9, 0x2000 + 0x0101 *  8,
+					0x2000 + 0x0101 *  7, 0x2000 + 0x0101 *  6,
+					0x2000 + 0x0101 *  5, 0x2000 + 0x0101 *  4,
+					0x2000 + 0x0101 *  3, 0x2000 + 0x0101 *  2,
+					0x2000 + 0x0101 *  1, 0x2000 + 0x0101 *  0
+				)
+			);
+			return _cvtmask64_u64(Interleave);
+		}
 	}  // namespace bitalg_detail
 
 	template<typename morton, typename coord>
 	inline morton m2D_e_BITALG(const coord x, const coord y) {
-		return morton(0);
+		return bitalg_detail::bitzip(
+			static_cast<coord>(x),
+			static_cast<coord>(y)
+		);
 	}
 
 	template<typename morton, typename coord>

--- a/test/libmorton_test.cpp
+++ b/test/libmorton_test.cpp
@@ -145,7 +145,7 @@ void registerFunctions() {
 	f3D_32_decode.push_back(decode_3D_32_wrapper("LUT Shifted ET", &m3D_d_sLUT_ET<uint_fast32_t, uint_fast16_t>));
 
 	// Register 3D BMI intrinsics if available
-#if defined(__BMI2__) || __AVX2__
+#if defined(__BMI2__)
 	f3D_64_encode.push_back(encode_3D_64_wrapper("BMI2 instruction set", &m3D_e_BMI<uint_fast64_t, uint_fast32_t>));
 	f3D_32_encode.push_back(encode_3D_32_wrapper("BMI2 instruction set", &m3D_e_BMI<uint_fast32_t, uint_fast16_t>));
 	f3D_64_decode.push_back(decode_3D_64_wrapper("BMI2 Instruction set", &m3D_d_BMI<uint_fast64_t, uint_fast32_t>));
@@ -153,7 +153,7 @@ void registerFunctions() {
 #endif
 
 	// Register 3D AVX512 intrinsics if available
-#if defined(__AVX512BITALG__) || __AVX2__
+#if defined(__AVX512BITALG__)
 	f3D_64_encode.push_back(encode_3D_64_wrapper("AVX512 instruction set", &m3D_e_BITALG<uint_fast64_t, uint_fast32_t>));
 	f3D_32_encode.push_back(encode_3D_32_wrapper("AVX512 instruction set", &m3D_e_BITALG<uint_fast32_t, uint_fast16_t>));
 	f3D_64_decode.push_back(decode_3D_64_wrapper("AVX512 Instruction set", &m3D_d_BITALG<uint_fast64_t, uint_fast32_t>));

--- a/test/libmorton_test.cpp
+++ b/test/libmorton_test.cpp
@@ -143,6 +143,14 @@ void registerFunctions() {
 	f3D_32_decode.push_back(decode_3D_32_wrapper("BMI2 Instruction set", &m3D_d_BMI<uint_fast32_t, uint_fast16_t>));
 #endif
 
+	// Register 3D AVX512 intrinsics if available
+#if defined(__AVX512BITALG__) || __AVX2__
+	f3D_64_encode.push_back(encode_3D_64_wrapper("AVX512 instruction set", &m3D_e_BITALG<uint_fast64_t, uint_fast32_t>));
+	f3D_32_encode.push_back(encode_3D_32_wrapper("AVX512 instruction set", &m3D_e_BITALG<uint_fast32_t, uint_fast16_t>));
+	f3D_64_decode.push_back(decode_3D_64_wrapper("AVX512 Instruction set", &m3D_d_BITALG<uint_fast64_t, uint_fast32_t>));
+	f3D_32_decode.push_back(decode_3D_32_wrapper("AVX512 Instruction set", &m3D_d_BITALG<uint_fast32_t, uint_fast16_t>));
+#endif
+
 	// Register 2D 64-bit encode functions	
 	f2D_64_encode.push_back(encode_2D_64_wrapper("LUT Shifted ET", &m2D_e_sLUT_ET<uint_fast64_t, uint_fast32_t>));
 	f2D_64_encode.push_back(encode_2D_64_wrapper("LUT Shifted", &m2D_e_sLUT<uint_fast64_t, uint_fast32_t>));

--- a/test/makefile
+++ b/test/makefile
@@ -1,7 +1,7 @@
 CC=g++
 CFLAGS=-O3 -m64 -std=c++11 -I ../libmorton/include/
 
-all: test bmi2
+all: test bmi2 avx512
 
 test:
 	$(CC) $(CFLAGS) libmorton_test.cpp -o libmorton_test
@@ -9,5 +9,8 @@ test:
 bmi2:
 	$(CC) $(CFLAGS) -march=haswell libmorton_test.cpp -o libmorton_test_bmi2
 
+avx512:
+	$(CC) $(CFLAGS) -march=icelake-client libmorton_test.cpp -o libmorton_test_avx512
+
 clean:
-	rm -f libmorton_test libmorton_test_bmi2
+	rm -f libmorton_test libmorton_test_bmi2 libmorton_test_avx512


### PR DESCRIPTION
Typing from an Icelake machine(`i7-1065G7`)!
I can peck at this again, even if it ends up slower in the 2D case it'll still be interesting as it can also solve the more _general_ case of trying to interleave the bits of three input variables in parallel possibly much faster than a series of `pext`/`pdep`.

Here's measured latency data from [uops.info](https://uops.info/table.html?search=vpshufbitqmb&cb_lat=on&cb_tp=on&cb_uops=on&cb_ports=on&cb_ICL=on&cb_measurements=on&cb_iaca30=on&cb_doc=on&cb_avx512=on) for `vpshufbitqmb`.

```
Instruction									Lat		TP			Uops	Ports
VPSHUFBITQMB (K, K, XMM, M128)	AVX512EVEX	[1;8]	1.00 / 1.00	3		1*p0+1*p23+1*p5
VPSHUFBITQMB (K, K, XMM, XMM)	AVX512EVEX	[1;8]	1.00 / 1.00	2		1*p0+1*p5
VPSHUFBITQMB (K, K, YMM, M256)	AVX512EVEX	[1;8]	1.00 / 1.00	3		1*p0+1*p23+1*p5
VPSHUFBITQMB (K, K, YMM, YMM)	AVX512EVEX	[1;8]	1.00 / 1.00	2		1*p0+1*p5
VPSHUFBITQMB (K, K, ZMM, M512)	AVX512EVEX	[1;8]	1.00 / 1.00	3		1*p0+1*p23+1*p5
VPSHUFBITQMB (K, K, ZMM, ZMM)	AVX512EVEX	[1;8]	1.00 / 1.00	2		1*p0+1*p5
VPSHUFBITQMB (K, XMM, M128)		AVX512EVEX	6		1.00 / 1.00	3		1*p0+1*p23+1*p5
VPSHUFBITQMB (K, XMM, XMM)		AVX512EVEX	6		1.00 / 1.00	2		1*p0+1*p5
VPSHUFBITQMB (K, YMM, M256)		AVX512EVEX	6		1.00 / 1.00	3		1*p0+1*p23+1*p5
VPSHUFBITQMB (K, YMM, YMM)		AVX512EVEX	6		1.00 / 1.00	2		1*p0+1*p5
VPSHUFBITQMB (K, ZMM, M512)		AVX512EVEX	6		1.00 / 1.00	3		1*p0+1*p23+1*p5
VPSHUFBITQMB (K, ZMM, ZMM)		AVX512EVEX	6		1.00 / 1.00	2		1*p0+1*p5			
```

compared to `pext`
```
Instruction						Lat		TP			Uops	Ports
PEXT (R32, R32, M32)	BMI2	[3;8]	1.00 / 1.00	2		1*p1+1*p23
PEXT (R32, R32, R32)	BMI2	3		1.00 / 1.00	1		1*p1
PEXT (R64, R64, M64)	BMI2	[3;8]	1.00 / 1.00	2		1*p1+1*p23
PEXT (R64, R64, R64)	BMI2	3		1.00 / 1.00	1		1*p1	
```

and `pdep`
```
Instruction						Lat		TP			Uops	Ports
PDEP (R32, R32, M32)	BMI2	[3;8]	1.00 / 1.00	2	1*p1+1*p23
PDEP (R32, R32, R32)	BMI2	3		1.00 / 1.00	1	1*p1
PDEP (R64, R64, M64)	BMI2	[3;8]	1.00 / 1.00	2	1*p1+1*p23
PDEP (R64, R64, R64)	BMI2	3		1.00 / 1.00	1	1*p1	
```