### PR TITLE
Fix compilation errors and add CMake scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,7 @@ ClientBin/
 *.[Pp]ublish.xml
 *.pfx
 *.publishsettings
+.vscode/
 
 # RIA/Silverlight projects
 Generated_Code/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,27 @@
+# CMake version > 3.8.2
+# This requirement is for the "cxx_std_11" variable in target_compile_features().
+cmake_minimum_required(VERSION 3.8.2)
+project(libmorton CXX)
+
+option(LIBMORTON_BUILD_TESTS "Build unit tests for libmorton" ON)
+
+add_library(libmorton INTERFACE)
+target_compile_features(libmorton
+  INTERFACE
+    cxx_std_11
+  )
+target_compile_options(libmorton
+  INTERFACE
+    -Wall
+    -Wextra
+    -Wpedantic
+  )
+target_include_directories(libmorton
+  INTERFACE
+    libmorton/include
+  )
+add_library(libmorton::libmorton ALIAS libmorton)
+
+if (LIBMORTON_BUILD_TESTS)
+    add_subdirectory(test)
+endif()

--- a/libmorton/include/morton2D.h
+++ b/libmorton/include/morton2D.h
@@ -59,7 +59,7 @@ namespace libmorton {
 
 	// HELPER METHOD for Early Termination LUT Encode
 	template<typename morton, typename coord>
-	inline morton compute2D_ET_LUT_encode(const coord c, const coord *LUT) {
+	inline morton compute2D_ET_LUT_encode(const coord c, const uint_fast16_t *LUT) {
 		unsigned long maxbit = 0;
 		if (findFirstSetBit<coord>(c, &maxbit) == 0) { return 0; }
 		morton answer = 0;

--- a/libmorton/include/morton2D.h
+++ b/libmorton/include/morton2D.h
@@ -4,6 +4,7 @@
 // Warning: morton.h will always point to the functions that use the fastest available method.
 
 #include <algorithm>
+#include <cmath>
 #include <stdint.h>
 #include "morton2D_LUTs.h"
 #include "morton_common.h"

--- a/libmorton/include/morton3D.h
+++ b/libmorton/include/morton3D.h
@@ -63,7 +63,7 @@ namespace libmorton {
 
 	// HELPER METHOD for ET LUT encode
 	template<typename morton, typename coord>
-	inline morton compute3D_ET_LUT_encode(const coord c, const coord *LUT) {
+	inline morton compute3D_ET_LUT_encode(const coord c, const uint_fast32_t *LUT) {
 		unsigned long maxbit = 0;
 		if (findFirstSetBit<coord>(c, &maxbit) == 0) { return 0; }
 		morton answer = 0;

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,0 +1,11 @@
+add_executable(libmorton_test
+  libmorton_test.cpp
+  )
+target_link_libraries(libmorton_test
+  PRIVATE
+    libmorton::libmorton
+  )
+target_include_directories(libmorton_test
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+  )

--- a/test/libmorton_test.cpp
+++ b/test/libmorton_test.cpp
@@ -40,7 +40,7 @@ vector<decode_2D_32_wrapper> f2D_32_decode; // 2D 32_bit decode functions
 void printRunningSums(){
 	uint_fast64_t t = 0;
 	cout << "    Running sums check: ";
-	for(int i = 0; i < running_sums.size(); i++) {
+	for(size_t i = 0; i < running_sums.size(); i++) {
 		t+= running_sums[i];
 	}
 	cout << t << endl;

--- a/test/libmorton_test_3D.h
+++ b/test/libmorton_test_3D.h
@@ -273,7 +273,7 @@ static double testDecode_3D_Random_Perf(void(*function)(const morton, coord&, co
 	}
 
 	// Start performance test
-	for (int t = 0; t < times; t++) {
+	for (size_t t = 0; t < times; t++) {
 		for (size_t i = 0; i < total; i++) {
 			m = randnumbers[i % RAND_POOL_SIZE];
 			timer.start();


### PR DESCRIPTION
Hi Danger,

I fixed some compilation errors which occurred in my environment, msys2 with mingw64:

- Narrowing conversion errors when passing the pointer of a lookup table.
- Undefined function error for std::floor function due to not including cmath.
- Warnings due to sign and unsigned integer comparisons in tests.

In addition, I added cmake scripts for cross-platform builds.
I hope these changes will help you.

Best,
Sho
