### PR TITLE
Added missing "defined" for ifs, which fixes compiler issues

### DIFF
--- a/libmorton/include/morton.h
+++ b/libmorton/include/morton.h
@@ -77,7 +77,7 @@ namespace libmorton {
 	inline void morton3D_64_decode(const uint_fast64_t morton, uint_fast32_t& x, uint_fast32_t& y, uint_fast32_t& z) {
 		m3D_d_BITALG<uint_fast64_t, uint_fast32_t>(morton, x, y, z);
 	}
-#elif defined(__BMI2__) || __AVX2__
+#elif defined(__BMI2__) || defined(__AVX2__)
 	inline void morton2D_32_decode(const uint_fast32_t morton, uint_fast16_t& x, uint_fast16_t& y) {
 		m2D_d_BMI<uint_fast32_t, uint_fast16_t>(morton, x, y);
 	}

--- a/libmorton/include/morton_BMI.h
+++ b/libmorton/include/morton_BMI.h
@@ -1,5 +1,5 @@
 #pragma once
-#if defined(__BMI2__) || __AVX2__
+#if defined(__BMI2__) || defined(__AVX2__)
 #include <immintrin.h>
 #include <stdint.h>
 

--- a/libmorton/include/morton_common.h
+++ b/libmorton/include/morton_common.h
@@ -3,14 +3,14 @@
 // Libmorton - Common helper methods needed in Morton encoding/decoding
 
 #include <stdint.h>
-#if _MSC_VER
+#if defined(_MSC_VER)
 #include <intrin.h>
 #endif
 
 namespace libmorton {
 	template<typename morton>
 	inline bool findFirstSetBitZeroIdx(const morton x, unsigned long* firstbit_location) {
-#if _MSC_VER && !_WIN64
+#if defined(_MSC_VER) && !defined(_WIN64)
 		// 32 BIT on 32 BIT
 		if (sizeof(morton) <= 4) {
 			return _BitScanReverse(firstbit_location, x) != 0;
@@ -24,10 +24,10 @@ namespace libmorton {
 			}
 			return _BitScanReverse(firstbit_location, (x & 0xFFFFFFFF)) != 0;
 		}
-#elif  _MSC_VER && _WIN64
+#elif defined(_MSC_VER) && defined(_WIN64)
 		// 32 or 64 BIT on 64 BIT
 		return _BitScanReverse64(firstbit_location, x) != 0;
-#elif __GNUC__
+#elif defined(__GNUC__)
 		if (x == 0) {
 			return false;
 		}

--- a/test/libmorton_test.cpp
+++ b/test/libmorton_test.cpp
@@ -93,14 +93,14 @@ void parseProgramParameters(int argc, char* argv[]) {
 void printHeader(){
 	cout << "LIBMORTON TEST SUITE" << endl;
 	cout << "--------------------" << endl;
-#if _WIN64 || __x86_64__  
+#if defined(_WIN64) || defined(__x86_64__)
 	cout << "++ 64-bit version" << endl;
 #else
 	cout << "++ 32-bit version" << endl;
 #endif
-#if _MSC_VER
+#if defined(_MSC_VER)
 	cout << "++ Compiled using MSVC " << _MSC_VER << endl;
-#elif __GNUC__
+#elif defined(__GNUC__)
     cout << "++ Compiled using GCC" << endl;
 #endif
 	cout << "++ Running tests until we've reached " << MAXRUNSIZE << "^3 codes" << endl;

--- a/test/timer.h
+++ b/test/timer.h
@@ -4,13 +4,13 @@
 
 #pragma once
 
-#if _MSC_VER
+#if defined(_MSC_VER)
 #include <Windows.h>
-#elif __GNUC__
+#elif defined(__GNUC__)
 #include "time.h"
 #endif
 
-#if _MSC_VER
+#if defined(_MSC_VER)
 struct Timer { 
 	double pc_frequency = 0.0;
 	double elapsed_time_milliseconds = 0.0;


### PR DESCRIPTION
Example compiler error: "_MSC_VER" is not defined [-Werror=undef]