### PR TITLE
Revert "Removed unused math.h"

### DIFF
--- a/libmorton/include/morton2D.h
+++ b/libmorton/include/morton2D.h
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <stdint.h>
+#include <math.h>
 #include "morton2D_LUTs.h"
 #include "morton_common.h"
 

--- a/libmorton/include/morton3D.h
+++ b/libmorton/include/morton3D.h
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <stdint.h>
+#include <math.h>
 #include "morton3D_LUTs.h"
 #include "morton_common.h"
 

--- a/test/libmorton_test.h
+++ b/test/libmorton_test.h
@@ -2,6 +2,7 @@
 
 // Standard headers
 #include <cstdlib>
+#include <math.h>
 #include <iostream>
 #include <sstream>
 #include <chrono>


### PR DESCRIPTION
This reverts commit 21bc33aae7759a730a6ec2b1de0523258e45a5cb.

```cpp
#include "libmorton/include/morton.h"

int main() {
	return 0;
}
```
compiled with
```
clang++ test.cpp -I.
```
produces these errors:
```
clang++ test.cpp -I.
In file included from test.cpp:1:
In file included from ./libmorton/include/morton.h:9:
./libmorton/include/morton2D.h:120:42: error: use of undeclared identifier 'floor'
                unsigned int checkbits = (unsigned int)floor(sizeof(morton) * 4.0f);
                                                       ^
In file included from test.cpp:1:
In file included from ./libmorton/include/morton.h:10:
./libmorton/include/morton3D.h:70:21: error: use of undeclared identifier 'ceil'
                for (int i = (int)ceil((maxbit + 1) / 8.0f); i >= 0; --i) {
                                  ^
./libmorton/include/morton3D.h:128:54: error: use of undeclared identifier 'floor'
                unsigned int checkbits = static_cast<unsigned int>(floor((sizeof(morton) * 8.0f / 3.0f)));
                                                                   ^
./libmorton/include/morton3D.h:145:54: error: use of undeclared identifier 'floor'
                unsigned int checkbits = static_cast<unsigned int>(floor((sizeof(morton) * 8.0f / 3.0f)));
                                                                   ^
./libmorton/include/morton3D.h:256:54: error: use of undeclared identifier 'floor'
                unsigned int checkbits = static_cast<unsigned int>(floor((sizeof(morton) * 8.0f / 3.0f)));
                                                                   ^
./libmorton/include/morton3D.h:273:23: error: use of undeclared identifier 'floor'
                float defaultbits = floor((sizeof(morton) * 8.0f / 3.0f));
                                    ^
6 errors generated.
```